### PR TITLE
Updated Configuring The OWIN Pipiline blog to point to a new address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 
 - .NET
-	- [ Configuring The OWIN Pipeline](http://blog.nankov.com/azure-mobile-services-configuring-the-owin-pipeline/)
+	- [ Configuring The OWIN Pipeline](http://www.newventuresoftware.com/blog/azure-mobile-services-configuring-the-owin-pipeline/)
 	- [ Insert/Update data with 1:n relationship using .NET backend ](http://blogs.msdn.com/b/azuremobile/archive/2014/06/18/insert-update-related-data-with-1-n-relationship-using-net-backend-azure-mobile-services.aspx)
  
 - Platform


### PR DESCRIPTION
I have moved my original blog post to a new URL where we have better formatting and we are regularly checking for comments. 
